### PR TITLE
Fix fallback image not resetting

### DIFF
--- a/src/components/DogCard.tsx
+++ b/src/components/DogCard.tsx
@@ -7,7 +7,7 @@ import {
   IconButton,
   Typography,
 } from '@mui/material';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Dog } from '../types';
 
 interface DogCardProps {
@@ -24,6 +24,10 @@ const DogCard = ({
   location,
 }: DogCardProps) => {
   const [imageError, setImageError] = useState(false);
+
+  useEffect(() => {
+    setImageError(false);
+  }, [dog.img]);
 
   const fallbackImage =
     'https://via.placeholder.com/200x200?text=No+Image+Available';


### PR DESCRIPTION
## Summary
- fix DogCard so fallback image resets when a new dog is displayed

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_68474c3616d8832d92ebb17fc936363e